### PR TITLE
fix: add workflow_dispatch to deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,6 +3,7 @@ name: Deploy
 on:
   push:
     branches: [main]
+  workflow_dispatch:  # Allow manual trigger from GitHub Actions UI
 
 jobs:
   build-and-push:


### PR DESCRIPTION
## Summary

- Adds `workflow_dispatch` trigger to the Deploy workflow so it can be run manually from the GitHub Actions UI without requiring a new push to `main`

## Context

The deploy workflow failed on the last run to `main` because the `data-latest` release (with the parquet assets) was created after the workflow had already started. With `workflow_dispatch`, the workflow can now be re-triggered manually from GitHub → Actions → Deploy → Run workflow once this PR is merged.

## Test plan

- [ ] Merge PR into `main`
- [ ] Go to GitHub → Actions → Deploy → Run workflow → confirm it completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)